### PR TITLE
bootstrap_connect is referenced before assignment

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # vars file for bootstrap
-
+bootstrap_connect: {}
 bootstrap_remote_user: "{{ (ansible_user | default(omit, true)) if bootstrap_connect is succeeded else bootstrap_user }}"
 
 # A string for each distribution and version of packages to install.


### PR DESCRIPTION
---
name: bootstrap_connect is referenced before assignment
about: default empty dict for bootstrap_connect

---

**Describe the change**
Added a default empty dict for bootstrap_connect ad bootstrap_remote_user is dependant on being present but its only set on line 20 in tasks/main.yml after bootstrap_remote_user is used on line 15
